### PR TITLE
fix: rename project to Powertools for AWS Lambda

### DIFF
--- a/.github/ISSUE_TEMPLATE/rfc.md
+++ b/.github/ISSUE_TEMPLATE/rfc.md
@@ -12,7 +12,7 @@ approved by: ''
 * RFC PR: (leave this empty)
 * Related issue(s), if known:
 * Area: (i.e. Tracer, Metrics, Logger, etc.)
-* Meet [tenets](https://github.com/awslabs/aws-lambda-powertools-roadmap#tenets): (Yes/no)
+* Meet [tenets](https://docs.powertools.aws.dev/lambda/python/latest/#tenets): (Yes/no)
 * Approved by: ''
 * Reviewed by: ''
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+MIT No Attribution
+
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -12,4 +14,3 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Powertools for AWS Lambda Roadmap
 
-This is the public roadmap for the open source library Powertools for AWS Lambda, currently available in [Python](https://github.com/awslabs/aws-lambda-powertools-python/), [Java](https://github.com/awslabs/aws-lambda-powertools-java/), and [Typescript](https://github.com/awslabs/aws-lambda-powertools-typescript).
+This is the public roadmap for the open source library Powertools for AWS Lambda, currently available in [Python](https://github.com/aws-powertools/powertools-lambda-python/), [Java](https://github.com/aws-powertools/powertools-lambda-java/), [Typescript](https://github.com/aws-powertools/powertools-lambda-typescript), and [dotnet](https://github.com/aws-powertools/powertools-lambda-dotnet).
 
 > Feature requests and RFCs created in the official repositories will be migrated here.
 
@@ -8,9 +8,9 @@ This is the public roadmap for the open source library Powertools for AWS Lambda
 
 Please use GitHub issues to raise feature requests, and RFCs to propose feature designs and major proposals that require further discussions.
 
-[See the roadmap »](https://github.com/awslabs/aws-lambda-powertools-roadmap/projects/1)
+[See the roadmap »](https://github.com/aws-powertools/powertools-lambda/projects/1)
 
-**NOTE**: We're progressively migrating to GitHub Projects Beta. We're starting with Python: https://awslabs.github.io/aws-lambda-powertools-python/latest/roadmap. As we complete and agree on a baseline and automation, we will repurpose this repository to be a landing page for feature parity across languages and more.
+**NOTE**: We're progressively migrating to GitHub Projects Beta. We're starting with Python: https://docs.powertools.aws.dev/lambda/python/latest/roadmap/. As we complete and agree on a baseline and automation, we will repurpose this repository to be a landing page for feature parity across languages and more.
 
 ### Roadmap structure
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## Lambda Powertools Roadmap
+## Powertools for AWS Lambda Roadmap
 
-This is the public roadmap for the open source library AWS Lambda Powertools, currently available in [Python](https://github.com/awslabs/aws-lambda-powertools-python/), [Java](https://github.com/awslabs/aws-lambda-powertools-java/), and [Typescript](https://github.com/awslabs/aws-lambda-powertools-typescript).
+This is the public roadmap for the open source library Powertools for AWS Lambda, currently available in [Python](https://github.com/awslabs/aws-lambda-powertools-python/), [Java](https://github.com/awslabs/aws-lambda-powertools-java/), and [Typescript](https://github.com/awslabs/aws-lambda-powertools-typescript).
 
 > Feature requests and RFCs created in the official repositories will be migrated here.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Replaces the name with the new branding _Powertools for AWS Lambda_


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
